### PR TITLE
fix(FEV-1548): when tab navigate to Read more\less buttons and hit space\enter the chapter is also triggered

### DIFF
--- a/src/ui-common/a11y-wrapper/a11y-wrapper.tsx
+++ b/src/ui-common/a11y-wrapper/a11y-wrapper.tsx
@@ -15,6 +15,7 @@ export const A11yWrapper = ({ children, onClick }: A11yWrapperProps) => {
     onKeyDown: (e: KeyboardEvent) => {
       if ([SPACE, ENTER].includes(e.keyCode)) {
         e.preventDefault();
+        e.stopPropagation();
         onClick(e, true);
       }
     },


### PR DESCRIPTION
**the issue:**
when tab navigate to Read more\less buttons and hit space\enter the chapter is also triggered.

**root cause:**
this is a regression- when event.stopPropagation() was removed from _handleExpandChange function in navigation plugin.

**solution:**
add event.stopPropagation() to onKeyDown in order to prevent further propagation.

Solves [FEV-1548](https://kaltura.atlassian.net/browse/FEV-1548)