### PR TITLE
fix(FEV-1536): remove max-width limitation on toast

### DIFF
--- a/src/ui-common/toast/_toast.scss
+++ b/src/ui-common/toast/_toast.scss
@@ -1,7 +1,6 @@
 .toastWrapper {
   position: relative;
   min-width: 120px;
-  max-width: 264px;
   height: 100%;
   border-radius: 4px;
   background-color: #222222;

--- a/src/ui-common/toasts-container/_toasts-container.scss
+++ b/src/ui-common/toasts-container/_toasts-container.scss
@@ -4,7 +4,6 @@
   top: 0;
   padding: 8px 16px 0;
   min-width: 120px;
-  max-width: 264px;
   display: flex;
   flex-direction: column;
 }
@@ -12,7 +11,6 @@
 .toastRow {
   height: 42px;
   min-width: 120px;
-  max-width: 264px;
   margin-bottom: 8px;
   overflow: hidden;
   overflow-wrap: break-word;


### PR DESCRIPTION
related to PR- https://github.com/kaltura/playkit-js-moderation/pull/45

since the new text from the new design is longer, needed to remove max-width, to allow the entire text to fit inside the toast.