### PR TITLE
fix(FEV-1536): change the width of the toast

### DIFF
--- a/src/ui-common/toast/_toast.scss
+++ b/src/ui-common/toast/_toast.scss
@@ -1,7 +1,7 @@
 .toastWrapper {
   position: relative;
   min-width: 120px;
-  max-width: 264px;
+  max-width: 310px;
   height: 100%;
   border-radius: 4px;
   background-color: #222222;

--- a/src/ui-common/toasts-container/_toasts-container.scss
+++ b/src/ui-common/toasts-container/_toasts-container.scss
@@ -4,7 +4,7 @@
   top: 0;
   padding: 8px 16px 0;
   min-width: 120px;
-  max-width: 264px;
+  max-width: 310px;
   display: flex;
   flex-direction: column;
 }
@@ -12,7 +12,7 @@
 .toastRow {
   height: 42px;
   min-width: 120px;
-  max-width: 264px;
+  max-width: 310px;
   margin-bottom: 8px;
   overflow: hidden;
   overflow-wrap: break-word;


### PR DESCRIPTION
related to PR- https://github.com/kaltura/playkit-js-moderation/pull/45

since the new text of moderation toast has changed, due to new design, needed to change the max-width of the toast.