### PR TITLE
fix(FEC-13130): #of/no results search should be announced

### DIFF
--- a/src/hoc/index.ts
+++ b/src/hoc/index.ts
@@ -1,2 +1,3 @@
 export * from './a11y-wrapper';
 export * from './overlay-portal';
+export * from './sr-wrapper';

--- a/src/hoc/sr-wrapper/index.tsx
+++ b/src/hoc/sr-wrapper/index.tsx
@@ -1,0 +1,27 @@
+import { h, createContext, Component } from "preact";
+import * as styles from './sr-wrapper.scss';
+
+export const ScreenReaderContext = createContext((textToRead: string, delay?: number) => {});
+export class ScreenReaderProvider extends Component {
+  state = {
+    textToRead: ''
+  }
+
+  private _setTextToRead = (text: string, delay = 500) => {
+    setTimeout(() => {
+      this.setState({textToRead: text})
+    }, delay);
+  };
+
+  render() {
+    return (
+      <ScreenReaderContext.Provider value={this._setTextToRead}>
+        {this.props.children}
+        <div style={styles.srWrapper} aria-live={'polite'}>
+          <span id='sr-only' aria-label={this.state.textToRead}>
+            {this.state.textToRead}
+          </span>
+        </div>
+      </ScreenReaderContext.Provider> );
+  }
+}

--- a/src/hoc/sr-wrapper/sr-wrapper.scss
+++ b/src/hoc/sr-wrapper/sr-wrapper.scss
@@ -1,0 +1,9 @@
+.sr-wrapper {
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  padding: 0;
+  margin: -1px;
+  border: 0;
+}


### PR DESCRIPTION
**Description of the changes:**
- adding screen reader wrapper component which is invisible to the user. its purpose is to solve the issue where the SR needs to announce on multiple updates; it wraps a span element which includes some text and reads it.

Solves [FEC-13130](https://kaltura.atlassian.net/browse/FEC-13130)