### PR TITLE
fix(FEC-13157): add data test id to screenReaderWrapper component

### DIFF
--- a/src/hoc/sr-wrapper/index.tsx
+++ b/src/hoc/sr-wrapper/index.tsx
@@ -17,7 +17,7 @@ export class ScreenReaderProvider extends Component {
     return (
       <ScreenReaderContext.Provider value={this._setTextToRead}>
         {this.props.children}
-        <div style={styles.srWrapper} aria-live={'polite'}>
+        <div style={styles.srWrapper} aria-live={'polite'} data-testid="screenReaderWrapper">
           <span id='sr-only' aria-label={this.state.textToRead}>
             {this.state.textToRead}
           </span>


### PR DESCRIPTION
add data test id to screenReaderWrapper component in order to add tests to it in navigation plugin.

**related PR-** https://github.com/kaltura/playkit-js-navigation/pull/321

Solves [FEC-13157](https://kaltura.atlassian.net/browse/FEC-13157)

[FEC-13157]: https://kaltura.atlassian.net/browse/FEC-13157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ