### PR TITLE
feat(FEC-13649): creating patch version for player

### DIFF
--- a/.github/workflows/canary_dependency.yaml
+++ b/.github/workflows/canary_dependency.yaml
@@ -20,7 +20,10 @@ on:
         default: '17.x'
 
 jobs:
+  set_stage:
+    uses: ./.github/workflows/set_stage_variable.yaml
   canary:
+    needs: set_stage
     uses: kaltura/ovp-pipelines-pub/.github/workflows/player_cicd.yaml@master
     secrets:
       PLAYER_CENTRAL_ACCOUNT_ID: ${{ secrets.PLAYER_CENTRAL_ACCOUNT_ID }}
@@ -34,7 +37,7 @@ jobs:
       PLAYER_GITHUB_KCONF_TOKEN: ${{ secrets.PLAYER_GITHUB_KCONF_TOKEN }}
     with:
       type: "dependency"
-      stage: "canary"
+      stage: ${{ needs.set_stage.outputs.stage }}
       node-version: ${{ inputs.node-version }}
       schema-type: ${{ inputs.schema-type }}
       tests-yarn-run-to-execute: ${{ inputs.tests-yarn-run-to-execute }}

--- a/.github/workflows/canary_player.yaml
+++ b/.github/workflows/canary_player.yaml
@@ -28,7 +28,10 @@ on:
         default: '17.x'
 
 jobs:
+  set_stage:
+    uses: ./.github/workflows/set_stage_variable.yaml
   canary:
+    needs: set_stage
     uses: kaltura/ovp-pipelines-pub/.github/workflows/player_cicd.yaml@master
     secrets:
       PLAYER_CENTRAL_ACCOUNT_ID: ${{ secrets.PLAYER_CENTRAL_ACCOUNT_ID }}
@@ -42,7 +45,7 @@ jobs:
       PLAYER_GITHUB_KCONF_TOKEN: ${{ secrets.PLAYER_GITHUB_KCONF_TOKEN }}
     with:
       type: "player"
-      stage: "canary"
+      stage: ${{ needs.set_stage.outputs.stage }}
       node-version: ${{ inputs.node-version }}
       schema-type: ${{ inputs.schema-type }}
       tests-yarn-run-to-execute: ${{ inputs.tests-yarn-run-to-execute }}

--- a/.github/workflows/canary_plugin.yaml
+++ b/.github/workflows/canary_plugin.yaml
@@ -35,7 +35,10 @@ on:
         default: 'true'
 
 jobs:
+  set_stage:
+    uses: ./.github/workflows/set_stage_variable.yaml
   canary:
+    needs: set_stage
     uses: kaltura/ovp-pipelines-pub/.github/workflows/player_cicd.yaml@master
     secrets:
       PLAYER_CENTRAL_ACCOUNT_ID: ${{ secrets.PLAYER_CENTRAL_ACCOUNT_ID }}
@@ -49,7 +52,7 @@ jobs:
       PLAYER_GITHUB_KCONF_TOKEN: ${{ secrets.PLAYER_GITHUB_KCONF_TOKEN }}
     with:
       type: "plugin"
-      stage: "canary"
+      stage: ${{ needs.set_stage.outputs.stage }}
       node-version: ${{ inputs.node-version }}
       schema-type: ${{ inputs.schema-type }}
       tests-yarn-run-to-execute: ${{ inputs.tests-yarn-run-to-execute }}

--- a/.github/workflows/set_stage_variable.yaml
+++ b/.github/workflows/set_stage_variable.yaml
@@ -1,0 +1,27 @@
+## Set Stage Variable
+name: Set Stage Variable
+run-name: Set Stage Variable
+
+on:
+  workflow_call:
+    outputs:
+      stage:
+        description: "stage"
+        value: ${{ jobs.set_stage_variable.outputs.stage }}
+
+jobs:
+  set_stage_variable:
+    runs-on: ubuntu-latest
+    outputs:
+      stage: ${{ steps.stage.outputs.stage }}
+    steps:
+      - name: Output stage
+        id: stage
+        run: |
+          if [[ ${GITHUB_REF#refs/heads/} == "patch-version" ]]; then
+            stage="patch"
+          else
+            stage="canary"
+          fi
+          echo $stage
+          echo "stage=${stage}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description of changes:
- add new workflow that outputs `stage`, according to current branch (optional values: `canary`, `patch`)
- use the workflow in all types of `canary_xyz` workflows
- pass the output of stage as parameter to canary job, instead of hard-coding `"canary"`

Solves [FEC-13649](https://kaltura.atlassian.net/browse/FEC-13649)

[FEC-13649]: https://kaltura.atlassian.net/browse/FEC-13649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ