### PR TITLE
fix(FEC-13673): keep overlay classname only for overlay component from playkit-js-ui

### DIFF
--- a/src/hoc/overlay-portal/index.tsx
+++ b/src/hoc/overlay-portal/index.tsx
@@ -7,6 +7,7 @@ const {
 const { createPortal } = KalturaPlayer.ui;
 
 const PORTAL_CLASS = '.overlay-portal';
+const PLAYKIT_OVERLAY_CLASS = '.playkit-overlay';
 
 export interface OverlayPortalProps {
   children: ComponentChild;
@@ -32,7 +33,7 @@ export class OverlayPortal extends Component<OverlayPortalProps> {
 
   componentWillUnmount() {
     // keep playkit-overlay-active class in case OverlayPortal has more children
-    if (this.playerContainer.querySelector(PORTAL_CLASS).children.length > 1) {
+    if (this.playerContainer.querySelector(`${PORTAL_CLASS} > ${PLAYKIT_OVERLAY_CLASS}`)) {
       // use timeout 0 to make sure addPlayerClass happens after removePlayerClass
       setTimeout(() => {
         this.props.addPlayerClass!();


### PR DESCRIPTION
resolves: FEC-13673