### PR TITLE
fix(ADA-1300): "Hide" button color scheme

### DIFF
--- a/src/components/button/Button.scss
+++ b/src/components/button/Button.scss
@@ -36,7 +36,7 @@
   }
   &.translucent {
     background-color: rgba(0, 0, 0, 0.6);
-    color: var(--playkit-primary-text-contrast-color);
+    color: $white;
   }
   &.borderless {
     background-color: transparent;


### PR DESCRIPTION
Issue: 
The button contrast is not good when the primary color is light

**Solution:**
Because the background is always gray text color should be white and not the primary contrast.

Solves [ADA-1300](https://kaltura.atlassian.net/browse/ADA-1300)

[ADA-1300]: https://kaltura.atlassian.net/browse/ADA-1300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ