### PR TITLE
fix(ADA-1393): Change focus background color to primary darker

### DIFF
--- a/src/components/button/Button.scss
+++ b/src/components/button/Button.scss
@@ -18,7 +18,7 @@
         background-color: var(--playkit-primary-darker-color);
       }
       &:focus {
-        background-color: var(--playkit-primary-brighter-color);
+        background-color: var(--playkit-primary-darker-color);
       }
     }
   }


### PR DESCRIPTION
Root cause:
- Autoscroll button background color for focus state was different from the hover state. In this conditions, the color contrast requirements were not met;

Change:
- Both focus and hover state have the same color as discussed with design team : --playkit-primary-darker-color;