### PR TITLE
fix(ADA-1612): Option to remove role that is set by default (Based on v1.2.10)

### DIFF
--- a/src/hoc/a11y-wrapper/index.tsx
+++ b/src/hoc/a11y-wrapper/index.tsx
@@ -12,7 +12,7 @@ interface A11yWrapperProps {
   onDownKeyPressed?: (e: KeyboardEvent) => void;
   onLeftKeyPressed?: (e: KeyboardEvent) => void;
   onRightKeyPressed?: (e: KeyboardEvent) => void;
-  role?: string;
+  role?: string | null;
   type?: string;
 }
 
@@ -59,10 +59,13 @@ export const A11yWrapper = ({
     onClick: (e: MouseEvent) => {
       onClick(e, isKeyboardEvent(e));
     },
-    role
   };
   if ((children as VNode)?.type  === 'button') {
     props.type = type || 'button';
+  }
+
+  if (role !== null) {
+    props.role = role;
   }
 
   return cloneElement(children as VNode, props);


### PR DESCRIPTION
With:
https://github.com/kaltura/playkit-js-ui-managers/pull/62

Issue: 
Generic role is for use by user agents and not by developers, so we must provide an option to remove the default role for this component.

The fix was added for playkit-js-ui-managers icon wrappers. That repo uses v1.2.10 version of this repo 

Fix: 
Providing null as a valid prop that will remove the role attribute making the html element generic without developer intervention that can be detected in the developer console.


