### PR TITLE
fix(SUP-43778):v7 Player Hotspot Text Formatting

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,13 +21,13 @@ jobs:
           install: false
           browser: chrome
       - name: Upload video
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-videos
           path: ./cypress/videos
       - name: Upload screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
@@ -52,13 +52,13 @@ jobs:
           install: false
           browser: firefox
       - name: Upload video
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-videos
           path: ./cypress/videos
       - name: Upload screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
@@ -82,13 +82,13 @@ jobs:
           install: false
           browser: edge
       - name: Upload video
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-videos
           path: ./cypress/videos
       - name: Upload screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots
@@ -114,13 +114,13 @@ jobs:
   #         install: false
   #         browser: webkit
   #     - name: Upload screenshots
-  #       uses: actions/upload-artifact@v2
+  #       uses: actions/upload-artifact@v3
   #       if: failure()
   #       with:
   #         name: cypress-screenshots
   #         path: ./cypress/screenshots
   #     - name: Upload video
-  #       uses: actions/upload-artifact@v2
+  #       uses: actions/upload-artifact@v3
   #       if: failure()
   #       with:
   #         name: cypress-videos


### PR DESCRIPTION
issue:
on hotspots repo there is an error:This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

solution:
upgrade actions/upload-artifact to v3