### PR TITLE
fix(ADA-1787): [ORS] - Firefox playerkit - Navigation/Playlist overlay not focused immediately when screen reader (NVDA) is activated

### DIFF
--- a/src/hoc/a11y-wrapper/index.tsx
+++ b/src/hoc/a11y-wrapper/index.tsx
@@ -1,5 +1,6 @@
 import {cloneElement, ComponentChild, VNode,} from 'preact';
 import { ui } from '@playkit-js/kaltura-player-js';
+import { Env } from '@playkit-js/playkit-js';
 const { ENTER, SPACE, UP, DOWN, LEFT, RIGHT } = ui.utils.KeyMap;
 
 export type OnClickEvent = KeyboardEvent | MouseEvent;
@@ -24,7 +25,9 @@ const stopEvent = (e: KeyboardEvent) => {
 export const isKeyboardEvent = (e: OnClickEvent): boolean => {
   // space/enter keyEvent is swallowed by NVDA (https://github.com/nvaccess/nvda/issues/7898)
   // check offsetX and offsetY to define keyboard event triggered by NVDA
-  return e instanceof KeyboardEvent || [e.offsetX, e.offsetY].every((offset) => offset === 0);
+  // firefox return offset = 18 in keyboard event and not 0
+  let offsetValue = Env.browser.name === 'Firefox' ? 18 : 0;
+  return e instanceof KeyboardEvent || [e.offsetX, e.offsetY].every((offset) => offset === offsetValue);
 };
 
 export const A11yWrapper = ({


### PR DESCRIPTION
**Issue:**
When navigation/playlist panel with keyboard and NVDA on, the focus is not moved into the panel area.

**Root cause**
In Firefox the offestX and offsetY is always 18 and not 0 so offset === 0 return false. so the onClick function get byKeyboard = false.

**Solution:**
If the browser if Firefox the compare will do with 18 and not 0

Solves [ADA-1787](https://kaltura.atlassian.net/browse/ADA-1787)

[ADA-1787]: https://kaltura.atlassian.net/browse/ADA-1787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ