### PR TITLE
QVA-3676 trigger automation after canary

### DIFF
--- a/.github/workflows/canary_plugin.yaml
+++ b/.github/workflows/canary_plugin.yaml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Trigger Workflow in Another Repository
         run: |
-          curl -L \
+          curl -L --fail \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.REPO_DISPATCH_TOKEN }}" \

--- a/.github/workflows/canary_plugin.yaml
+++ b/.github/workflows/canary_plugin.yaml
@@ -61,3 +61,16 @@ jobs:
       enabled-openssl-legacy-provider: ${{ inputs.enabled-openssl-legacy-provider }}
 
 
+  run_post_deploy_automation:
+    needs: canary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Workflow in Another Repository
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.REPO_DISPATCH_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/kaltura/player-v7-automation/dispatches \
+            -d '{"event_type": "trigger-workflow"}'

--- a/.github/workflows/canary_plugin.yaml
+++ b/.github/workflows/canary_plugin.yaml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Trigger Workflow in Another Repository
         run: |
-          curl -L --fail \
+          curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.REPO_DISPATCH_TOKEN }}" \


### PR DESCRIPTION
This pull request introduces a new job in the GitHub Actions workflow to trigger automation in another repository after the completion of the `canary` job.

### Workflow automation enhancement:
* [`.github/workflows/canary_plugin.yaml`](diffhunk://#diff-e04187b88ca574c5abb8fe383e05d54e257f667e4f5db0bcf9c440b87803f10bR64-R76): Added a new job `run_post_deploy_automation` that triggers a workflow in the `kaltura/player-v7-automation` repository using a `POST` request to the GitHub API. This job runs on `ubuntu-latest` and depends on the successful completion of the `canary` job.